### PR TITLE
Use base URL for Canva fallback

### DIFF
--- a/_layouts/prompt.html
+++ b/_layouts/prompt.html
@@ -194,12 +194,12 @@ h1{
     const hasRef = document.referrer && document.referrer !== location.href;
     if (hasRef) { window.history.back(); return; }
 
-    // Fallback per-type
-    const fallbackMap = {
-      kling: "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#7",
-      flux:  "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#6"
-    };
-    window.location.href = fallbackMap["{{ page.type }}"] || "{{ site.baseurl }}/";
+    // Fallback to a shared Canva design page.  Only the trailing page
+    // number changes, so we keep the base URL once and append the
+    // per-page number from front matter (e.g. `canva_page: 6`).
+    const canvaBase = "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#";
+    const pageNum = "{{ page.canva_page | default: '' }}";
+    window.location.href = pageNum ? canvaBase + pageNum : "{{ site.baseurl }}/";
   }
 
   async function copyIt(id){

--- a/_prompts/first-contact.md
+++ b/_prompts/first-contact.md
@@ -3,6 +3,7 @@ layout: prompt
 type: flux
 title: My Alien Host - First Contact
 badge_main: Flux Prompt
+canva_page: 6
 prompt: |
   Beneath violet-lit jungle vines, (your-trigger-word) watches a floating holographic panel glide up from the ground. The scene is hyper-realistic, with lifelike lighting and fog. Pulses of magenta trace across (his or her) forehead as he lifts his chin in realization, his face glowing with insight.
 ---


### PR DESCRIPTION
## Summary
- build fallback URL from a shared Canva base and page-specific number
- add `canva_page` front matter field to prompts for numeric fallback

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9124e71388329ae373ec045f6532b

## Summary by Sourcery

Streamline Canva fallback logic by using a shared base URL with a per-page suffix and add support for specifying page numbers via front matter.

Enhancements:
- Replace static per-type fallback map with a single shared Canva base URL appended with a page-specific number.
- Add a canva_page front matter field to prompt files to drive the numeric fallback.
- Fallback now redirects to the site base URL if no canva_page value is provided.