### PR TITLE
Use base URL for Canva fallback

### DIFF
--- a/_layouts/prompt.html
+++ b/_layouts/prompt.html
@@ -190,16 +190,23 @@ h1{
     const explicit = "{{ page.back_url | default: '' }}";
     if (explicit) { window.location.href = explicit; return; }
 
-    // Use history only if there is a real referrer
-    const hasRef = document.referrer && document.referrer !== location.href;
-    if (hasRef) { window.history.back(); return; }
+    // Prefer the original referrer when available.
+    const ref = document.referrer;
+    if (ref && ref !== location.href) {
+      if (window.history.length > 1) {
+        window.history.back();
+      } else {
+        window.location.href = ref;
+      }
+      return;
+    }
 
-    // Fallback per-type
-    const fallbackMap = {
-      kling: "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#7",
-      flux:  "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#6"
-    };
-    window.location.href = fallbackMap["{{ page.type }}"] || "{{ site.baseurl }}/";
+    // Fallback to a shared Canva design page.  Only the trailing page
+    // number changes, so we keep the base URL once and append the
+    // per-page number from front matter (e.g. `canva_page: 6`).
+    const canvaBase = "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#";
+    const pageNum = "{{ page.canva_page | default: '' }}";
+    window.location.href = pageNum ? canvaBase + pageNum : "{{ site.baseurl }}/";
   }
 
   async function copyIt(id){

--- a/_prompts/first-contact.md
+++ b/_prompts/first-contact.md
@@ -3,6 +3,7 @@ layout: prompt
 type: flux
 title: My Alien Host - First Contact
 badge_main: Flux Prompt
+canva_page: 6
 prompt: |
   Beneath violet-lit jungle vines, (your-trigger-word) watches a floating holographic panel glide up from the ground. The scene is hyper-realistic, with lifelike lighting and fog. Pulses of magenta trace across (his or her) forehead as he lifts his chin in realization, his face glowing with insight.
 ---


### PR DESCRIPTION
## Summary
- use referrer when present, otherwise build Canva link from base URL and per-page number

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68b9124e71388329ae373ec045f6532b

## Summary by Sourcery

Improve back-button logic to use the true referrer when available and default to a shared Canva link constructed from a base URL plus a per-page number

New Features:
- Add front-matter "canva_page" to specify the Canva fallback page number per prompt

Enhancements:
- Prefer document.referrer and history length for navigation before fallback
- Construct Canva fallback URL using a shared base URL with the page-specific fragment number