### PR TITLE
Use base URL for Canva fallback

### DIFF
--- a/_layouts/prompt.html
+++ b/_layouts/prompt.html
@@ -190,16 +190,25 @@ h1{
     const explicit = "{{ page.back_url | default: '' }}";
     if (explicit) { window.location.href = explicit; return; }
 
-    // Use history only if there is a real referrer
-    const hasRef = document.referrer && document.referrer !== location.href;
-    if (hasRef) { window.history.back(); return; }
+    // Prefer the original referrer when available, but ignore empty
+    // or stripped Canva origins that don't point to the actual design.
+    const ref = document.referrer;
+    const canvaOrigin = "https://www.canva.com";
+    if (ref && ref !== location.href && ref !== canvaOrigin && ref !== canvaOrigin + "/") {
+      if (window.history.length > 1) {
+        window.history.back();
+      } else {
+        window.location.href = ref;
+      }
+      return;
+    }
 
-    // Fallback per-type
-    const fallbackMap = {
-      kling: "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#7",
-      flux:  "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#6"
-    };
-    window.location.href = fallbackMap["{{ page.type }}"] || "{{ site.baseurl }}/";
+    // Fallback to a shared Canva design page.  Only the trailing page
+    // number changes, so we keep the base URL once and append the
+    // per-page number from front matter (e.g. `canva_page: 6`).
+    const canvaBase = "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#";
+    const pageNum = "{{ page.canva_page | default: '' }}";
+    window.location.href = pageNum ? canvaBase + pageNum : "{{ site.baseurl }}/";
   }
 
   async function copyIt(id){

--- a/_prompts/first-contact.md
+++ b/_prompts/first-contact.md
@@ -3,6 +3,7 @@ layout: prompt
 type: flux
 title: My Alien Host - First Contact
 badge_main: Flux Prompt
+canva_page: 6
 prompt: |
   Beneath violet-lit jungle vines, (your-trigger-word) watches a floating holographic panel glide up from the ground. The scene is hyper-realistic, with lifelike lighting and fog. Pulses of magenta trace across (his or her) forehead as he lifts his chin in realization, his face glowing with insight.
 ---


### PR DESCRIPTION
## Summary
- use referrer when present, otherwise build Canva link from base URL and per-page number
- ignore generic Canva referrers so back button returns to the design page

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b9124e71388329ae373ec045f6532b

## Summary by Sourcery

Improve Canva fallback behavior by preferring valid referrers and constructing fallback URLs from a shared base and per-page front-matter

Enhancements:
- Prefer genuine document.referrer over generic Canva origins, using history.back or direct redirect when available
- Replace hardcoded per-type Canva links with a shared base URL and append the per-page number from a new canva_page front matter
- Add canva_page front matter to the first-contact prompt to enable dynamic fallback URLs