### PR TITLE
Create linked prompt sections for mobile

### DIFF
--- a/_layouts/prompt.html
+++ b/_layouts/prompt.html
@@ -28,20 +28,24 @@ layout: null
       {%- endif -%}
     {%- endif -%}
 
-    {% include prompt-box.html
-      badge   = badge_label
-      field_id = 'content_main'
-      text    = page.prompt
-    %}
+    <section id="main" tabindex="-1">
+      {% include prompt-box.html
+        badge   = badge_label
+        field_id = 'content_main'
+        text    = page.prompt
+      %}
+    </section>
 
     <!-- Negative only for Kling -->
     {% if page.type == 'kling' and page.negative_prompt %}
-      {%- assign neg_badge = page.badge_negative | default: "Kling Negative Prompt" -%}
-      {% include prompt-box.html
-        badge   = neg_badge
-        field_id = 'content_negative'
-        text    = page.negative_prompt
-      %}
+      <section id="negative" tabindex="-1">
+        {%- assign neg_badge = page.badge_negative | default: "Kling Negative Prompt" -%}
+        {% include prompt-box.html
+          badge   = neg_badge
+          field_id = 'content_negative'
+          text    = page.negative_prompt
+        %}
+      </section>
       <button class="back-btn" onclick="goBack()">⬅️ Back</button>
     {% endif %}
   </div>
@@ -108,6 +112,22 @@ layout: null
     clearTimeout(tid);
     tid = setTimeout(()=> t.classList.remove('show'), 1200);
   }
+
+  // Deep-link handling for mobile: #main and #negative
+  document.addEventListener('DOMContentLoaded', function(){
+    const hash = (location.hash || '').toLowerCase();
+    if (hash === '#negative') {
+      const section = document.getElementById('negative');
+      if (section) section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const ta = document.getElementById('content_negative');
+      if (ta && typeof ta.focus === 'function') ta.focus();
+    } else if (hash === '#main') {
+      const section = document.getElementById('main');
+      if (section) section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const ta = document.getElementById('content_main');
+      if (ta && typeof ta.focus === 'function') ta.focus();
+    }
+  });
   </script>
 </body>
 </html>

--- a/alien-portal-kling-main-and-negative-pair.html
+++ b/alien-portal-kling-main-and-negative-pair.html
@@ -12,7 +12,7 @@
   --glass1: rgba(15,18,32,.9); --glass2: rgba(15,18,32,.7);
 }
 *{box-sizing:border-box}
-html,body{height:100%;margin:0;padding:0}
+html,body{height:100%;margin:0;padding:0;scroll-behavior:smooth}
 body{
   background: linear-gradient(120deg, var(--bg1), var(--bg2), var(--bg1));
   background-size: 320% 320%;
@@ -150,7 +150,7 @@ h1{
     <button class="back-btn" onclick="goBack()">⬅️ Back</button>
     <h1>Alien Portal - Stepping Through the Wormhole</h1>
 
-    <section class="card">
+    <section class="card" id="main">
       <div class="header-row">
         <div class="title">Kling Prompt</div>
         <button class="copy-btn" onclick="copyIt('content1')"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -197,6 +197,22 @@ function showToast(){
   clearTimeout(tid);
   tid=setTimeout(()=>t.classList.remove('show'), 1200);
 }
+
+// Deep-link handling for mobile: #main and #negative
+document.addEventListener('DOMContentLoaded', function(){
+  const hash = (location.hash || '').toLowerCase();
+  if (hash === '#negative') {
+    const section = document.getElementById('negative');
+    if (section) section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const ta = document.getElementById('content2');
+    if (ta && typeof ta.focus === 'function') ta.focus();
+  } else if (hash === '#main') {
+    const section = document.getElementById('main');
+    if (section) section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    const ta = document.getElementById('content1');
+    if (ta && typeof ta.focus === 'function') ta.focus();
+  }
+});
 </script>
 </body>
 </html>

--- a/assets/css/prompt.css
+++ b/assets/css/prompt.css
@@ -6,7 +6,7 @@
   --glass1: rgba(15,18,32,.9); --glass2: rgba(15,18,32,.7);
 }
 *{box-sizing:border-box}
-html,body{height:100%;margin:0;padding:0}
+html,body{height:100%;margin:0;padding:0;scroll-behavior:smooth}
 body{
   background: linear-gradient(120deg, var(--bg1), var(--bg2), var(--bg1));
   background-size: 320% 320%;


### PR DESCRIPTION
Add deep-linking and smooth scrolling to Kling prompt pages for direct navigation to main or negative prompts, improving mobile user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-0492740f-5d60-48a9-9cf1-e567ce8b9b08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0492740f-5d60-48a9-9cf1-e567ce8b9b08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Enable deep-link navigation to main and negative prompt sections on mobile with smooth scrolling and focus management.

New Features:
- Wrap main and negative prompts in dedicated sections with corresponding IDs and tabindex for deep linking.
- Add JavaScript to detect URL hash on DOMContentLoaded and smoothly scroll to and focus the targeted prompt section.
- Enable CSS smooth scrolling in prompt layouts to animate navigation to anchors.