### PR TITLE
refactor: move prompt scripts to external file

### DIFF
--- a/_layouts/prompt.html
+++ b/_layouts/prompt.html
@@ -12,7 +12,7 @@ layout: null
 
 <link rel="stylesheet" href="{{ '/assets/css/prompt.css' | relative_url }}">
 </head>
-<body>
+<body data-canva-page="{{ page.canva_page | default: '' }}" data-back-url="{{ page.back_url | default: '' }}" data-base-url="{{ site.baseurl }}">
   <div class="center">
     <button class="back-btn" onclick="goBack()">⬅️ Back</button>
 
@@ -47,71 +47,7 @@ layout: null
   </div>
 
   <div id="toast" class="toast" role="status" aria-live="polite">Copied!</div>
-
-  <script>
-  function goBack() {
-    // Optional explicit per-page URL via front matter: back_url: https://...
-    const explicit = "{{ page.back_url | default: '' }}";
-    if (explicit) { window.location.href = explicit; return; }
-
-    // Prefer the original referrer when available.
-    const ref = document.referrer;
-    if (ref && ref !== location.href) {
-      if (window.history.length > 1) {
-        window.history.back();
-      } else {
-        window.location.href = ref;
-      }
-      return;
-    }
-
-    // Fallback to a shared Canva design page.  Only the trailing page
-    // number changes, so we keep the base URL once and append the
-    // per-page number from front matter (e.g. `canva_page: 6`).
-    const canvaBase = "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#";
-    const pageNum = "{{ page.canva_page | default: '' }}";
-    window.location.href = pageNum ? canvaBase + pageNum : "{{ site.baseurl }}/";
-  }
-
-  async function copyIt(id){
-    const el = document.getElementById(id);
-    if (!el) return;
-
-    // Prefer .value for <textarea>, fall back to textContent for <div>/<pre>
-    const text = (typeof el.value === "string") ? el.value : (el.textContent || "");
-    if (!text) { showToast("Nothing to copy"); return; }
-
-    try {
-      await navigator.clipboard.writeText(text);
-      showToast("Copied!");
-    } catch (e) {
-      // Fallback for older/locked-down contexts
-      let ta = (el.tagName === "TEXTAREA") ? el : null;
-      if (!ta) {
-        ta = document.createElement("textarea");
-        ta.style.position = "fixed";
-        ta.style.opacity = "0";
-        ta.value = text;
-        document.body.appendChild(ta);
-      }
-      ta.focus();
-      ta.select();
-      try { document.execCommand("copy"); } catch(_) {}
-      if (ta !== el) document.body.removeChild(ta);
-      showToast("Copied!");
-    }
-  }
-
-  let tid;
-  function showToast(msg){
-    const t = document.getElementById('toast');
-    if (!t) return;
-    if (msg) t.textContent = msg;
-    t.classList.add('show');
-    clearTimeout(tid);
-    tid = setTimeout(()=> t.classList.remove('show'), 1200);
-  }
-  </script>
+  <script src="{{ '/assets/js/prompt.js' | relative_url }}"></script>
 </body>
 </html>
 

--- a/assets/js/prompt.js
+++ b/assets/js/prompt.js
@@ -1,0 +1,57 @@
+function goBack() {
+  const body = document.body;
+  const explicit = body.dataset.backUrl || '';
+  if (explicit) { window.location.href = explicit; return; }
+
+  const ref = document.referrer;
+  if (ref && ref !== location.href) {
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      window.location.href = ref;
+    }
+    return;
+  }
+
+  const canvaBase = "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#";
+  const pageNum = body.dataset.canvaPage || '';
+  const base = body.dataset.baseUrl || '';
+  window.location.href = pageNum ? canvaBase + pageNum : base + '/';
+}
+
+async function copyIt(id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  const text = (typeof el.value === 'string') ? el.value : (el.textContent || '');
+  if (!text) { showToast('Nothing to copy'); return; }
+
+  try {
+    await navigator.clipboard.writeText(text);
+    showToast('Copied!');
+  } catch (e) {
+    let ta = (el.tagName === 'TEXTAREA') ? el : null;
+    if (!ta) {
+      ta = document.createElement('textarea');
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      ta.value = text;
+      document.body.appendChild(ta);
+    }
+    ta.focus();
+    ta.select();
+    try { document.execCommand('copy'); } catch (_) {}
+    if (ta !== el) document.body.removeChild(ta);
+    showToast('Copied!');
+  }
+}
+
+let tid;
+function showToast(msg) {
+  const t = document.getElementById('toast');
+  if (!t) return;
+  if (msg) t.textContent = msg;
+  t.classList.add('show');
+  clearTimeout(tid);
+  tid = setTimeout(() => t.classList.remove('show'), 1200);
+}

--- a/assets/js/prompt.js
+++ b/assets/js/prompt.js
@@ -1,5 +1,5 @@
 function goBack() {
-  const body = document.body;
+  const {body} = document;
   const explicit = body.dataset.backUrl || '';
   if (explicit) { window.location.href = explicit; return; }
 

--- a/assets/js/prompt.js
+++ b/assets/js/prompt.js
@@ -4,7 +4,10 @@ function goBack() {
   if (explicit) { window.location.href = explicit; return; }
 
   const ref = document.referrer;
-  if (ref && ref !== location.href) {
+  const isCanvaReferrer = ref && ref.includes('canva.com');
+  
+  // For non-Canva referrers, use history.back() if possible
+  if (ref && ref !== location.href && !isCanvaReferrer) {
     if (window.history.length > 1) {
       window.history.back();
     } else {
@@ -13,6 +16,7 @@ function goBack() {
     return;
   }
 
+  // For Canva referrers or no referrer, always use Canva deep link or base URL
   const canvaBase = "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#";
   const pageNum = body.dataset.canvaPage || '';
   const base = body.dataset.baseUrl || '';


### PR DESCRIPTION
## Summary
- move inline prompt functions into `assets/js/prompt.js`
- expose page data via `<body>` data attributes and load new script in layout

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68bcd2e14ed083299f0b1bb1d7fd21dd

## Summary by Sourcery

Refactor prompt layout by moving inline JavaScript into an external file and pass necessary data through body data attributes

Enhancements:
- Extract inline prompt helper functions (goBack, copyIt, showToast) into assets/js/prompt.js
- Expose page and site values via data attributes on the body element
- Load the external prompt.js script in the prompt layout

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move inline prompt logic to an external script and pass required context via body data attributes, updating back-navigation handling.
> 
> - **Prompt Layout (`_layouts/prompt.html`)**:
>   - Add `data-canva-page`, `data-back-url`, and `data-base-url` to `<body>`.
>   - Remove inline JS; load external `assets/js/prompt.js`.
> - **New Script (`assets/js/prompt.js`)**:
>   - Implement `goBack()` using `body.dataset`, `document.referrer`, history fallback, and Canva deep link.
>   - Implement `copyIt()` with clipboard API and textarea fallback.
>   - Implement `showToast()` with timed visibility toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9a009c49f7568a4eda178180d7df0150e3fe9a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->