### PR TITLE
Fix prompt back button fallback navigation

### DIFF
--- a/_layouts/prompt.html
+++ b/_layouts/prompt.html
@@ -48,6 +48,21 @@ layout: null
 
   <div id="toast" class="toast" role="status" aria-live="assertive">Copied!</div>
 
+  {%- assign __baseurl = site.baseurl | default: '' -%}
+  {%- if __baseurl == '' -%}
+    {%- assign __baseurl_with_slash = '/' -%}
+  {%- else -%}
+    {%- assign __baseurl_with_slash = __baseurl | append: '/' -%}
+  {%- endif -%}
+
+  <script>
+    window.promptPageConfig = {
+      backUrl: {{ page.back_url | default: '' | jsonify }},
+      canvaPage: {{ page.canva_page | default: '' | jsonify }},
+      siteBase: {{ __baseurl_with_slash | jsonify }},
+      type: {{ page.type | default: '' | jsonify }}
+    };
+  </script>
   <script src="{{ '/assets/js/prompt.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/js/prompt.js
+++ b/assets/js/prompt.js
@@ -1,23 +1,26 @@
 function goBack() {
-  const explicit = "{{ page.back_url | default: '' }}";
-  if (explicit) { 
-    window.location.href = explicit; 
-    return; 
+  const cfg = window.promptPageConfig || {};
+
+  const explicit = cfg.backUrl || "";
+  if (explicit) {
+    window.location.href = explicit;
+    return;
   }
 
   const canvaBase = "https://www.canva.com/design/DAGtoI-rTGs/suzi8xtrpeit_xpwmzWJgw/view?utm_content=DAGtoI-rTGs&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=he24d1b06e2#";
-  const pageNum = "{{ page.canva_page | default: '' }}";
-  const deepCanva = pageNum ? canvaBase + pageNum : "{{ site.baseurl }}/";
+  const pageNum = cfg.canvaPage || "";
+  const siteBase = cfg.siteBase || "/";
 
   const ref = document.referrer || "";
   const isCanva = /(^https?:\/\/)?([^\/]+\.)?canva\.com(\/|$)/i.test(ref);
 
   if (!isCanva && ref && ref !== location.href && window.history.length > 1) {
     window.history.back();
-    return; 
-  }     
-  window.location.href = deepCanva;
-  
+    return;
+  }
+
+  const fallback = pageNum ? canvaBase + pageNum : siteBase;
+  window.location.href = fallback;
 }
 
 async function copyIt(id) {


### PR DESCRIPTION
## Summary
- pass prompt metadata from the layout into a shared window config
- update the back button script to read from the config instead of raw Liquid tags
- ensure the fallback URL resolves correctly on GitHub Pages instead of a literal Liquid string

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8269efbe08329a7c7c1b157b8b94c

## Summary by Sourcery

Fix prompt back button fallback navigation by refactoring to use runtime config for navigation parameters and ensuring correct fallback URL on GitHub Pages

Bug Fixes:
- Correct fallback URL computation to use resolved site base instead of raw Liquid tags

Enhancements:
- Populate window.promptPageConfig with backUrl, canvaPage, siteBase, and type in the prompt layout
- Update goBack() to read navigation parameters from promptPageConfig and handle explicit, history, and fallback navigation paths